### PR TITLE
fix line break compatible issue for stardict

### DIFF
--- a/wquery/service/localservice.py
+++ b/wquery/service/localservice.py
@@ -212,6 +212,10 @@ class StardictService(LocalService):
             self.index()
         try:
             result = self.builder[self.word]
+            result = result.strip()\
+                           .replace('\r\n', '<br />')\
+                           .replace('\r', '<br />')\
+                           .replace('\n', '<br />')
             return QueryResult(result=result) if result else self.default_result
         except:
             return self.default_result


### PR DESCRIPTION
If the dictionary content is in plain text (using markers like `\n` for newlines), we have to replace newline markers to HTML line break `<br />`